### PR TITLE
Hide symbols for static build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ int main(void) {
 
 ### Requirements
 
-- [Meson](https://mesonbuild.com/) for building
+- [Meson](https://mesonbuild.com/) (0.54.0 or later) for building
 
 ### Build whole project
 

--- a/include/str_match.h
+++ b/include/str_match.h
@@ -7,13 +7,18 @@
 extern "C" {
 #endif
 
+// Export APIs when shared build
 #ifndef _TSM_EXTERN
+#ifdef _TSM_STATIC
+#define _TSM_EXTERN extern
+#else  // _TSM_STATIC
 #ifdef _WIN32
 #define _TSM_EXTERN __declspec(dllexport) extern
-#else
+#else  // _WIN32
 #define _TSM_EXTERN __attribute__((visibility("default"))) extern
-#endif
-#endif
+#endif  // _WIN32
+#endif  // _TSM_STATIC
+#endif  // _TSM_EXTERN
 
 #define _TSM_ENUM(s) typedef int s; enum
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 project('tiny-str-match', 'c',
+    meson_version: '>=0.54.0',
     default_options: [
         'warning_level=3',              # always max warnings
         'c_std=c99',                    # strict C99
@@ -13,11 +14,28 @@ tsm_sources = [
     'src/re.c',
 ]
 
-tiny_str_match_lib = library('tiny_str_match',
-    tsm_sources,
-    install: true,
-    include_directories: include_directories('./include'),
-    gnu_symbol_visibility: 'hidden')
+if meson.version().version_compare('>=1.3.0')
+    tiny_str_match_lib = library('tiny_str_match',
+        tsm_sources,
+        c_static_args: ['-D_TSM_STATIC'],
+        install: true,
+        include_directories: include_directories('./include'),
+        gnu_symbol_visibility: 'hidden')
+else
+    # TODO: Remove this else block to support only meson 1.3.0 or later.
+    tsm_c_args = []
+    if get_option('default_library') == 'both'
+        error('tiny-str-match requres meson 1.3.0 or later to build both shared and static libraries at the same time')
+    elif get_option('default_library') == 'static'
+        tsm_c_args = ['-D_TSM_STATIC']
+    endif
+    tiny_str_match_lib = library('tiny_str_match',
+        tsm_sources,
+        c_args: tsm_c_args,
+        install: true,
+        include_directories: include_directories('./include'),
+        gnu_symbol_visibility: 'hidden')
+endif
 
 # dependency for other projects
 tiny_str_match_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ else
     # TODO: Remove this else block to support only meson 1.3.0 or later.
     tsm_c_args = []
     if get_option('default_library') == 'both'
-        error('tiny-str-match requres meson 1.3.0 or later to build both shared and static libraries at the same time')
+        error('tiny-str-match requires meson 1.3.0 or later to build both shared and static libraries at the same time')
     elif get_option('default_library') == 'static'
         tsm_c_args = ['-D_TSM_STATIC']
     endif


### PR DESCRIPTION
Symbols are hidden in static builds to make the compiler possible to remove unused functions.